### PR TITLE
Add SSG-VQA bridge, F1 metrics, and configurable BERT

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -32,6 +32,8 @@ def parse_args():
     # Choices of models
     parser.add_argument('--model', type=str, default='CFRF_Model', choices=['CFRF_Model'],
                         help='the model we use')
+    parser.add_argument('--bert_name', type=str, default='bert-base-uncased',
+                        help='Pretrained BERT checkpoint to use for language encoding')
 
     # INTERACTION LEARNING COMPONENTS HYPER-PARAMETERS------------------------------------------------------------------
     # BAN
@@ -176,8 +178,11 @@ if __name__ == '__main__':
     print("Evaluating...")
     model.train(False)
     criterion = torch.nn.BCEWithLogitsLoss(reduction='sum')
-    eval_cfrf_score, _, _, _, bound, eval_loss = evaluate(model, eval_loader, args, criterion)
+    eval_cfrf_score, _, _, _, bound, eval_loss, eval_metrics = evaluate(model, eval_loader, args, criterion)
     print('\tCFRF score: %.2f (%.2f)' % (100 * eval_cfrf_score, 100 * bound))
+    print('\tF1 macro: %.2f, F1 micro: %.2f' % (100 * eval_metrics.get('f1_macro', 0.0), 100 * eval_metrics.get('f1_micro', 0.0)))
+    for qtype, score in sorted(eval_metrics.get('f1_by_type', {}).items()):
+        print(f"\tF1[{qtype}]: {100 * score:.2f}")
 
 # if __name__ == '__main__':
 #     sweep_config = {

--- a/language_model.py
+++ b/language_model.py
@@ -111,8 +111,10 @@ class BertEmbedding(nn.Module):
     def __init__(self, args, max_seq_length):
         super(BertEmbedding, self).__init__()
 
+        bert_name = getattr(args, 'bert_name', 'bert-base-uncased')
+        do_lower_case = 'uncased' in bert_name.lower()
         # Using the bert tokenizer
-        self.tokenizer = BertTokenizer.from_pretrained("bert-base-uncased", do_lower_case=True)
+        self.tokenizer = BertTokenizer.from_pretrained(bert_name, do_lower_case=do_lower_case)
         self.max_seq_length = max_seq_length
 
         if args.from_scratch:
@@ -120,7 +122,7 @@ class BertEmbedding(nn.Module):
             self.model.apply(self.model.init_bert_weights)
 
         # Bert embedding
-        self.bert = BertFeatureExtraction.from_pretrained('bert-base-uncased', args=args)
+        self.bert = BertFeatureExtraction.from_pretrained(bert_name, args=args)
 
     def forward(self, sents):
         train_features = convert_sents_to_features(

--- a/main.py
+++ b/main.py
@@ -54,6 +54,8 @@ def parse_args():
                         help='the model we use')
     parser.add_argument('--dataset', type=str, default='GQA', choices=['GQA'],
                         help='Dataset to train and evaluate')
+    parser.add_argument('--bert_name', type=str, default='bert-base-uncased',
+                        help='Pretrained BERT checkpoint to initialise tokenizer and encoder')
 
     # INTERACTION LEARNING COMPONENTS HYPER-PARAMETERS------------------------------------------------------------------
     # BAN

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy
+h5py
+torch
+pandas
+wandb
+pytest
+pytest-cov
+ruff

--- a/src/FFOE/dataset.py
+++ b/src/FFOE/dataset.py
@@ -9,7 +9,6 @@ import os
 import json
 import _pickle as cPickle
 import numpy as np
-from torch import nn
 
 import src.utils as utils
 import warnings
@@ -18,6 +17,7 @@ with warnings.catch_warnings():
     import h5py
 import torch
 from torch.utils.data import Dataset
+from torch import nn
 import itertools
 COUNTING_ONLY = False
 
@@ -109,6 +109,7 @@ def _create_entry(img, question, answer, entity, teacher_logit):
     if None!=answer:  # {'image_id': 3455, 'labels': [439], 'question_id': '001000', 'scores': [1.0]}
         answer.pop('image_id')
         answer.pop('question_id')
+    question_type = question.get('question_type') or question.get('type') or 'unknown'
     entry = {
         'question_id' : question['question_id'],
         'image_id'    : question['image_id'],
@@ -116,6 +117,7 @@ def _create_entry(img, question, answer, entity, teacher_logit):
         'question'    : question['question'],
         'answer'      : answer,  # {'labels': [439], 'scores': [1.0]}
         'entity'      : entity,  # ['picture', 'in']
+        'question_type': question_type,
         'teacher_logit': teacher_logit}
     return entry
 
@@ -240,7 +242,10 @@ class GQAFeatureDataset(Dataset):
         # read the image_data.json, to get the width and height of the images, for normalising the bounding boxes
         self.image_data = json.load(open(os.path.join(dataroot, 'image_data.json'), 'rb'))
         # reform the dictionary
-        self.new_image_data = {image["image_id"]: {k: v for k, v in image.items() if k != "image_id"} for image in self.image_data}
+        if isinstance(self.image_data, dict):
+            self.new_image_data = self.image_data
+        else:
+            self.new_image_data = {image["image_id"]: {k: v for k, v in image.items() if k != "image_id"} for image in self.image_data}
 
 
         # Load image feature

--- a/src/FFOE/train.py
+++ b/src/FFOE/train.py
@@ -12,6 +12,8 @@ from lxrt.optimization import BertAdam
 import pandas as pd
 import pickle
 import wandb
+from src.metrics import f1_by_type, f1_macro_micro
+
 warmup_updates = 4000
 
 
@@ -187,15 +189,23 @@ def train(args, model, train_loader, eval_loader, num_epochs, output, opt=None, 
             trainer.model.train(False)
             # eval_cfrf_score: sum of the batch_score calculated by comparing the fusion_pred and ground truth
             # fusion_pred: weighted combination of ban_logits and lxmert_logits
-            eval_cfrf_score, fg_score, coarse_score, ens_score, bound, eval_loss = evaluate(model, eval_loader, args, criterion)
+            eval_cfrf_score, fg_score, coarse_score, ens_score, bound, eval_loss, eval_metrics = evaluate(model, eval_loader, args, criterion)
             trainer.model.train(True)
-            wandb.log({"eval_cfrf_score": eval_cfrf_score, "eval_loss": eval_loss})
+            wandb.log({
+                "eval_cfrf_score": eval_cfrf_score,
+                "eval_loss": eval_loss,
+                "eval_f1_macro": eval_metrics.get('f1_macro', 0.0),
+                "eval_f1_micro": eval_metrics.get('f1_micro', 0.0),
+            })
+            for qtype, score in eval_metrics.get('f1_by_type', {}).items():
+                wandb.log({f"eval_f1_{qtype}": score})
 
         logger.write('epoch %d, time: %.2f' % (epoch, time.time()-t))
         logger.write('\ttrain_loss: %.2f, norm: %.4f, score: %.2f, question type score: %.2f' %
                      (total_loss, total_norm/count_norm, train_score, train_question_type_score))
         if eval_loader is not None:
             logger.write('\tCFRF score: %.2f (%.2f)' % (100 * eval_cfrf_score, 100 * bound))
+            logger.write('\tF1 macro: %.2f, F1 micro: %.2f' % (100 * eval_metrics.get('f1_macro', 0.0), 100 * eval_metrics.get('f1_micro', 0.0)))
 
         # Save per epoch
         if epoch >= saving_epoch:
@@ -227,6 +237,9 @@ def evaluate(model, dataloader, args, criterion):
     n = 0  # num of batches in one epoch
     # df = pd.DataFrame(columns=["Img_id", "Questions", "Answers", "Predictions"])
     batch_dfs = []
+    all_preds = []
+    all_targets = []
+    question_types: list[str] = []
     with torch.no_grad():
         # features, spatials, stat_features, entity, attr_features, question, sent (tuple), target, imgid (tuple), ans
         for i, (v, b, w, e, attr, q, s, a, imgid, ans) in enumerate(dataloader):
@@ -302,6 +315,20 @@ def evaluate(model, dataloader, args, criterion):
                 })
 
                 batch_dfs.append(batch_df)
+            all_preds.append(final_preds.detach().cpu())
+            all_targets.append(a.detach().cpu())
+            start_index = num_data
+            entries = getattr(dataloader.dataset, 'entries', None)
+            if entries is not None:
+                for offset in range(final_preds.size(0)):
+                    entry_idx = start_index + offset
+                    if entry_idx < len(entries):
+                        question_types.append(entries[entry_idx].get('question_type', 'unknown'))
+                    else:
+                        question_types.append('unknown')
+            else:
+                question_types.extend(['unknown'] * final_preds.size(0))
+
             batch_scores = compute_score_with_logits(final_preds, a).sum()  # tensor(212., device='cuda:0')
             cfrf_score += batch_scores  # tensor(212., device='cuda:0')
             upper_bound += (a.max(1)[0]).sum()  # tensor(256., device='cuda:0')
@@ -319,5 +346,21 @@ def evaluate(model, dataloader, args, criterion):
         result_df = pd.concat(batch_dfs, ignore_index=True)
         result_df.to_csv(csv_path, index=False)
 
-    return cfrf_score, fg_score, coarse_score, ens_score, upper_bound, eval_losses
+    if all_preds:
+        preds_tensor = torch.cat(all_preds, dim=0)
+        targets_tensor = torch.cat(all_targets, dim=0)
+        f1_macro, f1_micro = f1_macro_micro(preds_tensor, targets_tensor)
+        f1_types = f1_by_type(preds_tensor, targets_tensor, question_types)
+    else:
+        f1_macro = 0.0
+        f1_micro = 0.0
+        f1_types = {}
+
+    metrics = {
+        'f1_macro': f1_macro,
+        'f1_micro': f1_micro,
+        'f1_by_type': f1_types,
+    }
+
+    return cfrf_score, fg_score, coarse_score, ens_score, upper_bound, eval_losses, metrics
 

--- a/src/metrics/__init__.py
+++ b/src/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""Metric utilities for CFRF."""
+
+from .f1 import f1_by_type, f1_macro_micro
+
+__all__ = ["f1_macro_micro", "f1_by_type"]

--- a/src/metrics/f1.py
+++ b/src/metrics/f1.py
@@ -1,0 +1,113 @@
+"""F1 score utilities for macro/micro aggregation and question-type splits."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Sequence, Tuple
+
+try:
+    import torch
+except ImportError:  # pragma: no cover - handled via test skips
+    torch = None  # type: ignore[assignment]
+
+
+def _require_torch() -> None:
+    if torch is None:  # pragma: no cover - guarded by tests
+        raise ImportError("torch is required for F1 metric computation")
+
+
+def _confusion_matrix(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    _require_torch()
+    if pred.ndim != 1 or target.ndim != 1:
+        raise ValueError("pred and target must be 1-D class indices")
+    if pred.numel() != target.numel():
+        raise ValueError("pred and target must have the same number of elements")
+    num_classes = (
+        int(max(pred.max().item(), target.max().item())) + 1 if pred.numel() else 0
+    )
+    if num_classes == 0:
+        return torch.zeros((0, 0), dtype=torch.long)
+    indices = target * num_classes + pred
+    conf = torch.bincount(indices, minlength=num_classes * num_classes)
+    return conf.view(num_classes, num_classes)
+
+
+def _prepare_predictions(
+    pred: torch.Tensor, target: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    _require_torch()
+    if pred.ndim != 2 or target.ndim != 2:
+        raise ValueError("pred and target must be 2-D tensors")
+    if pred.shape != target.shape:
+        raise ValueError("pred and target must have the same shape")
+    pred_ids = pred.argmax(dim=1)
+    target_ids = target.argmax(dim=1)
+    return pred_ids.cpu(), target_ids.cpu()
+
+
+def f1_macro_micro(pred: torch.Tensor, target: torch.Tensor) -> Tuple[float, float]:
+    """Compute macro and micro F1 scores from logits and one-hot labels."""
+
+    _require_torch()
+    pred_ids, target_ids = _prepare_predictions(pred, target)
+    if pred_ids.numel() == 0:
+        return 0.0, 0.0
+    conf = _confusion_matrix(pred_ids, target_ids)
+    if conf.numel() == 0:
+        return 0.0, 0.0
+    tp = conf.diag().to(torch.float32)
+    fp = conf.sum(dim=0).to(torch.float32) - tp
+    fn = conf.sum(dim=1).to(torch.float32) - tp
+
+    denom = 2 * tp + fp + fn
+    class_f1 = torch.where(denom > 0, 2 * tp / denom, torch.zeros_like(tp))
+    support = conf.sum(dim=1)
+    macro = class_f1[support > 0].mean().item() if (support > 0).any() else 0.0
+
+    tp_total = tp.sum()
+    fp_total = fp.sum()
+    fn_total = fn.sum()
+    micro_denom = 2 * tp_total + fp_total + fn_total
+    micro = (2 * tp_total / micro_denom).item() if micro_denom > 0 else 0.0
+    return macro, micro
+
+
+def f1_by_type(
+    pred: torch.Tensor, target: torch.Tensor, qtypes: Sequence[str]
+) -> Dict[str, float]:
+    """Compute F1 scores grouped by question type."""
+
+    _require_torch()
+    pred_ids, target_ids = _prepare_predictions(pred, target)
+    if pred_ids.numel() != len(qtypes):
+        raise ValueError("Number of question types must match batch size")
+    buckets: Dict[str, Dict[str, torch.Tensor]] = defaultdict(
+        lambda: {"pred": [], "target": []}
+    )
+    for idx, qtype in enumerate(qtypes):
+        buckets[qtype]["pred"].append(pred_ids[idx])
+        buckets[qtype]["target"].append(target_ids[idx])
+
+    results: Dict[str, float] = {}
+    for qtype, tensors in buckets.items():
+        pred_tensor = (
+            torch.stack(tensors["pred"]) if tensors["pred"] else torch.empty(0)
+        )
+        target_tensor = (
+            torch.stack(tensors["target"]) if tensors["target"] else torch.empty(0)
+        )
+        if pred_tensor.numel() == 0:
+            results[qtype] = 0.0
+            continue
+        conf = _confusion_matrix(pred_tensor, target_tensor)
+        if conf.numel() == 0:
+            results[qtype] = 0.0
+            continue
+        tp = conf.diag().to(torch.float32)
+        fp = conf.sum(dim=0).to(torch.float32) - tp
+        fn = conf.sum(dim=1).to(torch.float32) - tp
+        denom = 2 * tp + fp + fn
+        f1 = torch.where(denom > 0, 2 * tp / denom, torch.zeros_like(tp))
+        support = conf.sum(dim=1)
+        results[qtype] = f1[support > 0].mean().item() if (support > 0).any() else 0.0
+    return results

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,217 @@
+import argparse
+import json
+import pickle
+import sys
+from pathlib import Path
+
+import pytest
+
+np = pytest.importorskip("numpy")
+h5py = pytest.importorskip("h5py")
+torch = pytest.importorskip("torch")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.ssgvqa_to_cfrf import build_answer_tables, run_pipeline  # noqa: E402
+from src.FFOE.dataset import Dictionary, GQAFeatureDataset  # noqa: E402
+
+
+@pytest.fixture()
+def sample_ssg(tmp_path):
+    splits = ["train", "val"]
+    features_root = tmp_path / "features"
+    boxes_root = tmp_path / "boxes"
+    qa_root = tmp_path / "qa"
+    sg_root = tmp_path / "scene"
+    meta_entries = []
+
+    vocab_terms = set()
+
+    for split in splits:
+        for root in (features_root / split, boxes_root / split, sg_root / split):
+            root.mkdir(parents=True, exist_ok=True)
+        questions = []
+        for idx in range(2):
+            image_id = f"{split}_img{idx}"
+            num_boxes = idx + 1
+            features = np.full((num_boxes, 4), fill_value=idx + 1, dtype=np.float32)
+            np.savez(features_root / split / f"{image_id}.npz", features=features)
+            width, height = 640, 480
+            boxes = []
+            for box_idx in range(num_boxes):
+                x1 = 10 * (box_idx + 1)
+                y1 = 5 * (box_idx + 1)
+                x2 = x1 + 20
+                y2 = y1 + 10
+                boxes.append([x1, y1, x2, y2])
+            with (boxes_root / split / f"{image_id}.json").open(
+                "w", encoding="utf-8"
+            ) as fp:
+                json.dump({"boxes": boxes, "width": width, "height": height}, fp)
+            scene = {
+                "objects": [
+                    {"name": "Grasper", "attributes": ["metal"]},
+                    {"name": "liver", "attributes": ["healthy"]},
+                ],
+                "relations": [
+                    {"subject": "grasper", "predicate": "touching", "object": "liver"}
+                ],
+            }
+            with (sg_root / split / f"{image_id}.json").open(
+                "w", encoding="utf-8"
+            ) as fp:
+                json.dump(scene, fp)
+            question_text = "Is the grasper touching the liver?"
+            vocab_terms.update(question_text.lower().replace("?", "").split())
+            answer = "yes" if idx % 2 == 0 else "no"
+            vocab_terms.add(answer)
+            questions.append(
+                {
+                    "question_id": f"{image_id}_q{idx}",
+                    "image_id": image_id,
+                    "question": question_text,
+                    "question_type": "binary",
+                    "answer": answer,
+                }
+            )
+            meta_entries.append(
+                {"image_id": image_id, "width": width, "height": height}
+            )
+        with (qa_root / f"{split}.json").open("w", encoding="utf-8") as fp:
+            json.dump({"questions": questions}, fp)
+
+    meta_path = tmp_path / "meta.json"
+    with meta_path.open("w", encoding="utf-8") as fp:
+        json.dump(meta_entries, fp)
+
+    dictionary_path = tmp_path / "dictionary.pkl"
+    vocab_list = sorted(vocab_terms | {"metal", "healthy", "touching"})
+    word2idx = {word: idx for idx, word in enumerate(vocab_list)}
+    with dictionary_path.open("wb") as fp:
+        pickle.dump((word2idx, vocab_list), fp)
+
+    out_root = tmp_path / "out"
+    args = argparse.Namespace(
+        qa_dir=str(qa_root),
+        scene_graph_dir=str(sg_root),
+        features_dir=str(features_root),
+        yolo_boxes_dir=str(boxes_root),
+        meta_path=str(meta_path),
+        out_dir=str(out_root),
+        topk=2,
+    )
+    run_pipeline(args)
+    return {
+        "out_root": out_root,
+        "dictionary_path": dictionary_path,
+        "splits": splits,
+    }
+
+
+def test_bridge_outputs_shapes_and_targets(sample_ssg):
+    out_root = sample_ssg["out_root"]
+    cache_dir = out_root / "cache"
+
+    with (cache_dir / "ans2label.pkl").open("rb") as fp:
+        ans2label = pickle.load(fp)
+    with (cache_dir / "label2ans.pkl").open("rb") as fp:
+        label2ans = pickle.load(fp)
+
+    assert len(ans2label) == len(label2ans)
+    assert all(label2ans[ans2label[label]] == label for label in ans2label)
+
+    for split in sample_ssg["splits"]:
+        h5_name = "ori_train.hdf5" if split == "train" else f"{split}.hdf5"
+        with h5py.File(out_root / h5_name, "r") as fp:
+            image_features = fp["image_features"][:]
+            spatial_features = fp["spatial_features"][:]
+            pos_boxes = fp["pos_boxes"][:]
+        assert image_features.dtype == np.float32
+        assert spatial_features.dtype == np.float32
+        assert pos_boxes.dtype == np.int32
+        assert image_features.shape[0] == spatial_features.shape[0]
+        assert pos_boxes.shape[0] == 2
+        assert pos_boxes[0, 0] == 0
+        assert pos_boxes[-1, 1] == image_features.shape[0]
+        assert np.all(spatial_features >= 0.0)
+        assert np.all(spatial_features <= 1.0 + 1e-6)
+
+        with (cache_dir / f"{split}_target.pkl").open("rb") as fp:
+            targets = pickle.load(fp)
+        assert len(targets) == 2
+        for target in targets:
+            assert target["scores"] == [1.0]
+            label = target["labels"][0]
+            assert label2ans[label] in {"yes", "no"}
+
+        question_path = out_root / f"gqa_{split}_questions_entities.json"
+        payload = json.loads(question_path.read_text(encoding="utf-8"))
+        for entry in payload["questions"]:
+            assert "question_type" in entry
+            assert entry["entities"]
+
+        stat_words_path = out_root / f"{split}_2_stats_words.json"
+        assert stat_words_path.exists()
+        attr_words_path = out_root / f"{split}_attr_words_non_plural_words.json"
+        assert attr_words_path.exists()
+
+        imgid2idx_path = out_root / f"{split}_imgid2idx.pkl"
+        with imgid2idx_path.open("rb") as fp:
+            mapping = pickle.load(fp)
+        assert len(mapping) == 2
+        assert all(isinstance(v, int) for v in mapping.values())
+
+
+def test_dataset_getitem_shapes(sample_ssg):
+    out_root = sample_ssg["out_root"]
+    dictionary = Dictionary.load_from_file(str(sample_ssg["dictionary_path"]))
+    args = argparse.Namespace(
+        max_boxes=5,
+        question_len=12,
+        num_stat_word=2,
+        use_ope=False,
+        device=torch.device("cpu"),
+        topk=2,
+        tiny=False,
+    )
+    dataset = GQAFeatureDataset(
+        args, "train", dictionary, dataroot=str(out_root), adaptive=True
+    )
+    sample = dataset[0]
+    (
+        features,
+        spatials,
+        stat_features,
+        entity,
+        attr_features,
+        question,
+        sent,
+        target,
+        img_id,
+        ans,
+    ) = sample
+    assert features.shape[0] <= args.max_boxes
+    assert features.shape[1] == dataset.v_dim
+    assert torch.all((spatials >= 0.0) & (spatials <= 1.0))
+    assert target.shape[0] == dataset.num_ans_candidates
+    assert torch.isclose(target.sum(), torch.tensor(1.0))
+    assert isinstance(sent, str)
+    assert dataset.entries[0]["question_type"] == "binary"
+
+
+def test_build_answer_tables_requires_answers(tmp_path):
+    qa_root = tmp_path / "qa"
+    qa_root.mkdir()
+    bad_question = {
+        "questions": [
+            {
+                "question_id": "q1",
+                "image_id": "img1",
+                "question": "Is there an instrument?",
+            }
+        ]
+    }
+    with (qa_root / "train.json").open("w", encoding="utf-8") as fp:
+        json.dump(bad_question, fp)
+    with pytest.raises(ValueError):
+        build_answer_tables(str(qa_root), str(tmp_path / "cache"))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.metrics import f1_by_type, f1_macro_micro
+
+torch = pytest.importorskip("torch")
+
+
+def test_f1_macro_micro_perfect_prediction():
+    logits = torch.tensor([[5.0, 1.0], [0.1, 2.5]])
+    target = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    macro, micro = f1_macro_micro(logits, target)
+    assert macro == pytest.approx(1.0)
+    assert micro == pytest.approx(1.0)
+
+
+def test_f1_by_type_handles_mixed_results():
+    logits = torch.tensor([[3.0, 0.5], [1.0, 2.0], [0.1, 0.2]])
+    target = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0]])
+    types = ["binary", "count", "binary"]
+    scores = f1_by_type(logits, target, types)
+    assert set(scores.keys()) == {"binary", "count"}
+    assert scores["binary"] < 1.0
+    assert 0.0 <= scores["count"] <= 1.0

--- a/tools/ssgvqa_to_cfrf.py
+++ b/tools/ssgvqa_to_cfrf.py
@@ -1,0 +1,480 @@
+"""Utilities to bridge SSG-VQA assets to the CFRF cache layout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, Mapping, MutableMapping, Sequence, Tuple
+
+import numpy as np
+
+try:
+    import h5py
+except ImportError:  # pragma: no cover - handled in tests via skip
+    h5py = None
+
+JsonDict = MutableMapping[str, object]
+
+
+def _normalise_token(token: str) -> str:
+    return token.lower().strip()
+
+
+def _load_questions(source: Path) -> List[JsonDict]:
+    with source.open("r", encoding="utf-8") as fp:
+        payload = json.load(fp)
+    if isinstance(payload, Mapping) and "questions" in payload:
+        questions = payload["questions"]
+    elif isinstance(payload, Sequence):
+        questions = payload
+    else:
+        raise ValueError(f"Unrecognised QA format in {source}")
+    result: List[JsonDict] = []
+    for item in questions:
+        if not isinstance(item, Mapping):
+            raise ValueError(f"Question entry must be a mapping, got {type(item)!r}")
+        if (
+            "question_id" not in item
+            or "image_id" not in item
+            or "question" not in item
+        ):
+            raise KeyError(f"Missing keys in question entry from {source}: {item}")
+        result.append(dict(item))
+    return result
+
+
+def _resolve_scene_path(root: Path, image_id: str) -> Path | None:
+    candidates = [root / f"{image_id}.json", root / image_id / "scene.json"]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _scene_graph_vocabulary(
+    scene_graph: Mapping[str, object],
+) -> Tuple[Counter, List[str]]:
+    vocab: Counter = Counter()
+    attr_phrases: List[str] = []
+    objects = scene_graph.get("objects", [])
+    if isinstance(objects, Mapping):
+        objects = list(objects.values())
+    for obj in objects or []:
+        if not isinstance(obj, Mapping):
+            continue
+        name = obj.get("name")
+        if isinstance(name, str) and name:
+            vocab.update(_normalise_token(name).split())
+        attributes = obj.get("attributes")
+        if isinstance(attributes, Mapping):
+            attributes = list(attributes.values())
+        for attr in attributes or []:
+            if isinstance(attr, str) and attr:
+                attr_clean = _normalise_token(attr)
+                vocab.update(attr_clean.split())
+                if isinstance(name, str) and name:
+                    phrase = f"{attr_clean} {_normalise_token(name)}".strip()
+                else:
+                    phrase = attr_clean
+                attr_phrases.append(phrase)
+    relations = scene_graph.get("relations", [])
+    if isinstance(relations, Mapping):
+        relations = list(relations.values())
+    for rel in relations or []:
+        if not isinstance(rel, Mapping):
+            continue
+        predicate = rel.get("predicate")
+        if isinstance(predicate, str) and predicate:
+            vocab.update(_normalise_token(predicate).split())
+        for role in ("subject", "object"):
+            role_val = rel.get(role)
+            if isinstance(role_val, str) and role_val:
+                vocab.update(_normalise_token(role_val).split())
+    return vocab, attr_phrases
+
+
+def build_hdf5(features_dir: str, yolo_boxes_dir: str, out_h5: str) -> Dict[str, int]:
+    """Create an HDF5 cache with features, spatial data and positional boxes.
+
+    Returns a mapping from image_id to positional index used for pos_boxes.
+    """
+
+    if h5py is None:  # pragma: no cover - environment without h5py
+        raise ImportError("h5py is required to build HDF5 caches")
+
+    feature_root = Path(features_dir)
+    boxes_root = Path(yolo_boxes_dir)
+    if not feature_root.exists() or not boxes_root.exists():
+        raise FileNotFoundError("Feature or boxes directory does not exist")
+
+    image_features: List[np.ndarray] = []
+    spatial_features: List[np.ndarray] = []
+    pos_boxes: List[Tuple[int, int]] = []
+    image_ids: List[str] = []
+    cursor = 0
+
+    feature_files = sorted(
+        [p for p in feature_root.glob("**/*") if p.suffix.lower() in {".npz", ".npy"}]
+    )
+    if not feature_files:
+        raise FileNotFoundError(f"No feature files found in {feature_root}")
+
+    for feat_path in feature_files:
+        rel = feat_path.relative_to(feature_root)
+        image_id = rel.with_suffix("").as_posix()
+        box_path = boxes_root / rel.with_suffix(".json")
+        if not box_path.exists():
+            raise FileNotFoundError(f"Missing YOLO boxes for {image_id} at {box_path}")
+        if feat_path.suffix.lower() == ".npz":
+            with np.load(feat_path) as data:
+                if "features" not in data:
+                    raise KeyError(
+                        f"NPZ file {feat_path} must contain a 'features' array"
+                    )
+                features = data["features"].astype(np.float32)
+        else:
+            features = np.load(feat_path).astype(np.float32)
+        with box_path.open("r", encoding="utf-8") as fp:
+            box_payload = json.load(fp)
+        boxes = box_payload.get("boxes")
+        width = box_payload.get("width")
+        height = box_payload.get("height")
+        if boxes is None or width is None or height is None:
+            raise KeyError(
+                f"Boxes file {box_path} must define 'boxes', 'width' and 'height'"
+            )
+        boxes_arr = np.asarray(boxes, dtype=np.float32)
+        if boxes_arr.ndim != 2 or boxes_arr.shape[1] != 4:
+            raise ValueError(f"Boxes in {box_path} must have shape (num_boxes, 4)")
+        if features.shape[0] != boxes_arr.shape[0]:
+            raise ValueError(
+                f"Feature/box mismatch for {image_id}: {features.shape[0]} vs {boxes_arr.shape[0]}"
+            )
+        if width <= 0 or height <= 0:
+            raise ValueError(f"Invalid image size ({width}, {height}) for {image_id}")
+        width = float(width)
+        height = float(height)
+        x1, y1, x2, y2 = boxes_arr.T
+        widths = np.clip(x2 - x1, a_min=0.0, a_max=None)
+        heights = np.clip(y2 - y1, a_min=0.0, a_max=None)
+        spatial = np.stack(
+            [
+                x1 / width,
+                y1 / height,
+                x2 / width,
+                y2 / height,
+                widths / width,
+                heights / height,
+            ],
+            axis=1,
+        ).astype(np.float32)
+        spatial = np.clip(spatial, 0.0, 1.0)
+
+        start = cursor
+        cursor += features.shape[0]
+        pos_boxes.append((start, cursor))
+        image_features.append(features)
+        spatial_features.append(spatial)
+        image_ids.append(image_id)
+
+    image_features_arr = np.concatenate(image_features, axis=0)
+    spatial_features_arr = np.concatenate(spatial_features, axis=0)
+    pos_boxes_arr = np.asarray(pos_boxes, dtype=np.int32)
+
+    out_path = Path(out_h5)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with h5py.File(out_path, "w") as fp:
+        fp.create_dataset("image_features", data=image_features_arr, dtype="float32")
+        fp.create_dataset(
+            "spatial_features", data=spatial_features_arr, dtype="float32"
+        )
+        fp.create_dataset("pos_boxes", data=pos_boxes_arr, dtype="int32")
+
+    return {img_id: idx for idx, img_id in enumerate(image_ids)}
+
+
+def build_image_data(meta_path: str, out_json: str) -> None:
+    meta_source = Path(meta_path)
+    if not meta_source.exists():
+        raise FileNotFoundError(f"Metadata file not found: {meta_source}")
+    with meta_source.open("r", encoding="utf-8") as fp:
+        payload = json.load(fp)
+    image_dict: Dict[str, Dict[str, int]] = {}
+    if isinstance(payload, Mapping):
+        items = payload.items()
+    elif isinstance(payload, Sequence):
+        items = []
+        for item in payload:
+            if isinstance(item, Mapping):
+                key = str(item.get("image_id") or item.get("id"))
+                items.append((key, item))
+    else:
+        raise ValueError("Unsupported metadata format")
+
+    for key, value in items:
+        if not key:
+            continue
+        if not isinstance(value, Mapping):
+            continue
+        width = value.get("width")
+        height = value.get("height")
+        if width is None or height is None:
+            continue
+        image_dict[str(key)] = {"width": int(width), "height": int(height)}
+
+    out_path = Path(out_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as fp:
+        json.dump(image_dict, fp, indent=2, sort_keys=True)
+
+
+def build_qa_entities(
+    qa_dir: str, scene_graph_dir: str, out_json: str
+) -> List[JsonDict]:
+    qa_path = Path(qa_dir)
+    if qa_path.is_dir():
+        raise ValueError("qa_dir must point to a QA json file for a specific split")
+    questions = _load_questions(qa_path)
+    scene_root = Path(scene_graph_dir)
+    results: List[JsonDict] = []
+    missing_scene: set[str] = set()
+
+    scene_cache: Dict[str, Tuple[Counter, List[str]]] = {}
+
+    for question in sorted(questions, key=lambda x: x["question_id"]):
+        image_id = str(question["image_id"])
+        scene_tuple = scene_cache.get(image_id)
+        if scene_tuple is None:
+            scene_path = _resolve_scene_path(scene_root, image_id)
+            if scene_path and scene_path.exists():
+                with scene_path.open("r", encoding="utf-8") as fp:
+                    scene_data = json.load(fp)
+                scene_tuple = _scene_graph_vocabulary(scene_data)
+            else:
+                missing_scene.add(image_id)
+                scene_tuple = (Counter(), [])
+            scene_cache[image_id] = scene_tuple
+        vocab, _ = scene_tuple
+        question_tokens = [
+            _normalise_token(tok)
+            for tok in question["question"].replace("?", "").split()
+        ]
+        entities = sorted({tok for tok in question_tokens if tok and tok in vocab})
+        qtype = question.get("question_type") or question.get("type") or "unknown"
+        results.append(
+            {
+                "image_id": image_id,
+                "question": question["question"],
+                "question_id": question["question_id"],
+                "question_type": qtype,
+                "entities": entities,
+            }
+        )
+
+    out_path = Path(out_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as fp:
+        json.dump({"questions": results}, fp, indent=2)
+    if missing_scene:
+        skip_path = out_path.with_name(out_path.stem + "_missing_scene.json")
+        with skip_path.open("w", encoding="utf-8") as fp:
+            json.dump(sorted(missing_scene), fp, indent=2)
+    return results
+
+
+def _normalise_answer(answer: str) -> str:
+    return " ".join(_normalise_token(answer).split())
+
+
+def build_answer_tables(
+    qa_dir: str, out_dir: str
+) -> Tuple[Dict[str, int], List[str], Dict[str, List[JsonDict]]]:
+    qa_root = Path(qa_dir)
+    if not qa_root.exists():
+        raise FileNotFoundError(f"QA directory not found: {qa_root}")
+    if not qa_root.is_dir():
+        raise ValueError("qa_dir must be a directory containing split json files")
+
+    questions_by_split: Dict[str, List[JsonDict]] = {}
+    answers: List[str] = []
+    for qa_file in sorted(qa_root.glob("*.json")):
+        split = qa_file.stem
+        questions = _load_questions(qa_file)
+        questions_by_split[split] = questions
+        for question in questions:
+            if "answer" not in question or question["answer"] in (None, ""):
+                raise ValueError(
+                    f"Missing answer for question {question['question_id']}"
+                )
+            answers.append(str(question["answer"]))
+
+    if not answers:
+        raise ValueError("No answers found to build answer tables")
+
+    normalised_answers = sorted({_normalise_answer(ans) for ans in answers})
+    ans2label = {ans: idx for idx, ans in enumerate(normalised_answers)}
+    label2ans = list(normalised_answers)
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    with (out_path / "ans2label.pkl").open("wb") as fp:
+        import pickle
+
+        pickle.dump(ans2label, fp)
+    with (out_path / "label2ans.pkl").open("wb") as fp:
+        import pickle
+
+        pickle.dump(label2ans, fp)
+
+    for split, questions in questions_by_split.items():
+        targets = []
+        for question in sorted(questions, key=lambda x: x["question_id"]):
+            ans_norm = _normalise_answer(str(question["answer"]))
+            ans_idx = ans2label[ans_norm]
+            targets.append(
+                {
+                    "image_id": str(question["image_id"]),
+                    "question_id": question["question_id"],
+                    "labels": [ans_idx],
+                    "scores": [1.0],
+                }
+            )
+        cache_dir = out_path
+        with (cache_dir / f"{split}_target.pkl").open("wb") as fp:
+            import pickle
+
+            pickle.dump(targets, fp)
+
+    return ans2label, label2ans, questions_by_split
+
+
+def build_stat_attr_words(
+    scene_graph_dir: str,
+    out_stat_json: str,
+    out_attr_json: str,
+    topk: int = 30,
+) -> Tuple[Dict[str, str], Dict[str, List[str]]]:
+    scene_root = Path(scene_graph_dir)
+    if not scene_root.exists():
+        raise FileNotFoundError(f"Scene graph directory not found: {scene_root}")
+
+    stat_words: Dict[str, str] = {}
+    attr_words: Dict[str, List[str]] = {}
+    stat_skip: List[str] = []
+    attr_skip: List[str] = []
+
+    for scene_path in sorted(scene_root.glob("*.json")):
+        image_id = scene_path.stem
+        with scene_path.open("r", encoding="utf-8") as fp:
+            scene_data = json.load(fp)
+        vocab, attr_phrases = _scene_graph_vocabulary(scene_data)
+        if vocab:
+            most_common = [word for word, _ in vocab.most_common(topk)]
+            stat_words[image_id] = ",".join(most_common)
+        else:
+            stat_skip.append(image_id)
+        if attr_phrases:
+            attr_words[image_id] = attr_phrases[:topk]
+        else:
+            attr_skip.append(image_id)
+
+    out_stat_path = Path(out_stat_json)
+    out_stat_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_stat_path.open("w", encoding="utf-8") as fp:
+        json.dump(stat_words, fp, indent=2, sort_keys=True)
+    stat_skip_path = out_stat_path.with_name(
+        out_stat_path.stem.replace("_stats_words", "_stats_skip_imgid") + ".json"
+    )
+    with stat_skip_path.open("w", encoding="utf-8") as fp:
+        json.dump(stat_skip, fp, indent=2)
+
+    out_attr_path = Path(out_attr_json)
+    with out_attr_path.open("w", encoding="utf-8") as fp:
+        json.dump(attr_words, fp, indent=2, sort_keys=True)
+    attr_skip_path = out_attr_path.with_name(
+        out_attr_path.stem.replace("_attr_words_non_plural_words", "_attr_skip_imgid")
+        + ".json"
+    )
+    with attr_skip_path.open("w", encoding="utf-8") as fp:
+        json.dump(attr_skip, fp, indent=2)
+
+    return stat_words, attr_words
+
+
+def _write_imgid2idx(mapping: Dict[str, int], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("wb") as fp:
+        import pickle
+
+        pickle.dump(mapping, fp)
+
+
+def run_pipeline(args: argparse.Namespace) -> None:
+    out_root = Path(args.out_dir)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    build_image_data(args.meta_path, out_root / "image_data.json")
+    ans2label, label2ans, questions_by_split = build_answer_tables(
+        args.qa_dir, out_root / "cache"
+    )
+
+    for split, questions in questions_by_split.items():
+        features_split = Path(args.features_dir) / split
+        boxes_split = Path(args.yolo_boxes_dir) / split
+        h5_name = "ori_train.hdf5" if split == "train" else f"{split}.hdf5"
+        img_mapping = build_hdf5(
+            str(features_split), str(boxes_split), str(out_root / h5_name)
+        )
+        _write_imgid2idx(img_mapping, out_root / f"{split}_imgid2idx.pkl")
+
+        sg_split = Path(args.scene_graph_dir) / split
+        build_qa_entities(
+            str(Path(args.qa_dir) / f"{split}.json"),
+            str(sg_split),
+            str(out_root / f"gqa_{split}_questions_entities.json"),
+        )
+        build_stat_attr_words(
+            str(sg_split),
+            str(out_root / f"{split}_{args.topk}_stats_words.json"),
+            str(out_root / f"{split}_attr_words_non_plural_words.json"),
+            topk=args.topk,
+        )
+
+    # Ensure answer tables are serialised (already handled in build_answer_tables)
+    # Additional metadata can be added here if needed.
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert SSG-VQA assets to CFRF caches"
+    )
+    parser.add_argument(
+        "--qa_dir", required=True, help="Directory containing split QA json files"
+    )
+    parser.add_argument(
+        "--scene_graph_dir", required=True, help="Directory with scene graphs per split"
+    )
+    parser.add_argument(
+        "--features_dir",
+        required=True,
+        help="Directory with ROI feature npz/npy files per split",
+    )
+    parser.add_argument(
+        "--yolo_boxes_dir",
+        required=True,
+        help="Directory with YOLO box json files per split",
+    )
+    parser.add_argument("--meta_path", required=True, help="Image metadata json file")
+    parser.add_argument(
+        "--out_dir", required=True, help="Output directory for CFRF caches"
+    )
+    parser.add_argument(
+        "--topk", type=int, default=30, help="Number of statistical words per image"
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    run_pipeline(parse_args())


### PR DESCRIPTION
## Summary
- add an SSG-VQA to CFRF cache conversion tool with supporting requirements
- extend the dataset and training loop to track question types and report F1 metrics
- expose a configurable BERT checkpoint option across CLI and language model setup
- add unit tests for the bridge pipeline and F1 utilities

## Testing
- pytest -q *(fails: missing numpy/h5py/torch in environment, tests skipped via importorskip)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6a141d548322a1aff74cae56c5c7